### PR TITLE
163-cycle-score Digit Exploder

### DIFF
--- a/09-Zero-Preservation-Initiative.speed.asm
+++ b/09-Zero-Preservation-Initiative.speed.asm
@@ -1,27 +1,20 @@
 -- HUMAN RESOURCE MACHINE PROGRAM --
 
-    JUMP     g
+    INBOX   
+    JUMPZ    b
+    INBOX   
+    JUMPZ    a
 a:
 b:
 c:
 d:
 e:
-f:
     OUTBOX  
-g:
-h:
-    INBOX   
-    JUMPZ    a
-    INBOX   
-    JUMPZ    b
-    INBOX   
-    JUMPZ    c
-    INBOX   
-    JUMPZ    d
     INBOX   
     JUMPZ    e
     INBOX   
-    JUMPZ    f
-    JUMP     h
+    JUMPZ    d
+    INBOX   
+    JUMPZ    c
 
 

--- a/35-Duplicate-Removal.speed.asm
+++ b/35-Duplicate-Removal.speed.asm
@@ -1,98 +1,61 @@
 -- HUMAN RESOURCE MACHINE PROGRAM --
 
-    COMMENT  0
-    COPYFROM 14
-    COPYTO   13
-    COPYTO   12
     INBOX   
-    COPYTO   [13]
+    COPYTO   0
     OUTBOX  
-    BUMPUP   13
-    COMMENT  1
 a:
-b:
     INBOX   
-    COPYTO   11
-    SUB      [12]
+    COPYTO   1
+    SUB      0
     JUMPZ    a
-    JUMP     d
-    COMMENT  3
-c:
-    COPYFROM [12]
-    SUB      11
-    JUMPZ    e
-d:
-    BUMPUP   12
-    SUB      13
-    JUMPN    c
-    COMMENT  4
-    COPYFROM 11
-    COPYTO   [13]
+    COPYFROM 1
     OUTBOX  
-    BUMPUP   13
-    COMMENT  2
+b:
+c:
+    INBOX   
+    COPYTO   2
+    SUB      0
+    JUMPZ    b
+    COPYFROM 2
+    SUB      1
+    JUMPZ    c
+    COPYFROM 2
+    OUTBOX  
+d:
 e:
-    COPYFROM 14
-    COPYTO   12
-    JUMP     b
-
-
-DEFINE COMMENT 0
-eJyTZWBgYBb6ZMos1Do/VHj1LiCXoUcuvO6B3PxNtxWa5tYp5/ZVqia3l6klteVppnXmaOX07tWumLZD
-d/Z6kNpXVkltdtYQ9gxLjVgQvdH/utJG/7z+LX6t87f4rdgBElNwC6z6HBZYpZUU08QwCkbBKBg0AAA2
-rih8;
-
-DEFINE COMMENT 1
-eJyzYGBg4Nf9YHJa7YPJWdXPZj1y8mGvpVwKp0kVTLCXLp9qLte2oEWxf9kJ9elrUnSnrAIqZ3hk61Vq
-aZvWaWnbu9TYfuIKbaeJK8679C6V9qiffdAzrfOgZ2DVQc/mecLe6/fu9zpyRsLz9EU1l2s37axv3vY0
-v3wdZMbEaOcC+yjnAvfwyIbPYdUzXke2Lbgd37EQJMeV90iLK8+9eG1B4xwQv6MutUOzKbWjoiWh9WRr
-eF1pq3fZlUaXQuM6p/wn1QGVz6timiZVFU6cUF09o6OubYFac+/S1O7epdy9XYsZRsEoGAV4AQBbGl+H
-;
-
-DEFINE COMMENT 2
-eJyTZWBg2CjA6rJRQC06gT+0dgv/tkMMYLFvFqfVvlmA2AzC1llTpK2zQMyjGkltRzUWbQGxCzX0k0D0
-UpP4lqUm09f4mc7ftNh0++HFprPWfTFrnPPJvHrGfbvMbm2nzO7zLqVTFNwa55S6bdrPMApGwSgYNAAA
-hFgpIA;
-
-DEFINE COMMENT 3
-eJxLYWBgUFd5b/xB4r2xv+g3i1BhFuc1QsJ+a4R0E5aIWmZeVfIqVVUNrKpUjahXVS2epKU8Ybmp/IZ9
-fbLbDk2T2nXUX3T3sSCRzQeWi6zfCzSKYbN+Xv9m/bkbog2WbvtvtH7vL5NN+2dYbtrfa7tkq7H9xBXG
-9gUTQOpyPV/q53rqJ+3xTm7n8120hc83r5/bL6GVwz+maX1ARL1/SGTDu4jiSa4RjXOWhExcsSZw1jqQ
-vr1ZSW05mUltZ1OKJ6mmNM5RTZm+5mzK7PUn0pZsFc9cui24aOk2z7L5m0BqnStyep0rGuc4Vk5Yblc1
-eaVlzeSVrfW9S6uaG+ecaSmZfKYlrlmhtWluQfvSbQXtl64db7t1p6LlyWPNplfPX1V+fc9S8PW9UPan
-tyCzXKeH1n6eGlr7e1Jc88qJxZNWTpyxdsnk2ev7Zs9eD5I/u1jI9+zi9K7TS/qXgfh/NhZPerWjcOKk
-nbl91ruS2+12xrd82hpa+31zeN2Gdbl9m9eWTI5bO3ll9LrZ6/9sXLTFe8uSrTf3LdnKMApGAZ0BAPfR
-vKo;
-
-DEFINE COMMENT 4
-eJxzYmBgqFRldnotxeI8T1zQx1dMMuiHqFq0l7hDnqtkYNUzmYj62wrRjUc1ohvFteJbRLSzeg5oNc2V
-0Zi8sk553sY2hYWb/UUXbmYQnrcRaBTDF7PAKk/zggkzLEunWNpWTDO2r5jW6lA6Rdk1taPCNaQGpGaj
-/zeLjf5m6cyBQdXrA1rnhwdG1IcGhdS4h3uVPov2Kn0Q612mnxBR3xaf0/sgtnTKvLCKaSB9kQW7jrIU
-/LP7X/jHZlb5X9v7tfzeIPHd2aG1jpXhdSD28Ta3ouNtVdNB7CPtfF4ges0Ep/w1Eyqm/ZgcUf9hmlvR
-6xn2uZ1z7XPb5jkX6C6Ib2lc0DyPYRSMghEKAGbbZTU;
-
-DEFINE LABEL 11
-eJwzZWBg4OZ/Z5TAL+ofJagd7yvWOMdVcuVOXSXfcinNN4ZAaQYmo9DaOP3Q2t06Ca0i2hXTMrW7FvPr
-Tl65WX/WOhbDWevCjKat/mXSOv+LWWTDLIvqGY5WPUueW09bDdJ70fmz2UVni4wql6S2k25TVoHE1gSG
-1KwJbJ0fGtS12D+kd6lTZNfiF1FV0/tiIhv6YpLb2+Kb591I6FkCUsufk9a5tiCt809RUptfSWitX4lf
-xdoC77KczKBqqYz4lqPpdbMOZHYuSsyduCK4aNrq9+UQe0fBKBgFxAEArtxWDg;
-
-DEFINE LABEL 12
-eJxzZ2BguKH417ZH7q/tBwkeT18xyaBQYducNULeZWuEktpChQsnfhPrXfpMZsbaCyoz1p5VnbYaqIVh
-gVl43WLTiHo/07jmxaadi2ZZTFk11WrG2g77Wev0HCevbHJsnnfToXhSh3161yPb+JZP5t5lIH0Snt5l
-uZ7N89YE9i/7F9S/LCi4c1FQMNCeoMAqkHxfjF9FX0zHwgexTXN1E5Pba5JDa0+nBlTKpAdU5mWE1ORk
-JrUdyKyfDVLrV8Lt4VcyfxOIzVIQ2TCjIrIBxFZuKZks15bWKdcWWnuxKbT2ekNcs2F9bp9hff+yi00z
-1u7vnLeRecK8jSC1yyfFtyyf1LNkyeSCCZ+nJrW9mx7d+GJmRL3ugvA6hlEwCkYAAACG5nWs;
-
-DEFINE LABEL 13
-eJxzYmBgSOV9qpPKqxW3na9/2UaBiStWCk9c4S/au/SufMdCfcXmebpKzfOAyhg264fWfjELqfli5lex
-1MS5YK2hfe4GA4e8zfqeJVv1vMt26MY08egVTNhgUD/7j3HX4ldWnYtA+tRcXArVXMqnnnfpXXrGtXOR
-glvdrIOekQ0c/iE14YEhNQxBMU2hQSWTlwdD7MnJ9KsoSfOrqEwJrdVKyurRSqqaXpdUN0sqo3V+Zlbz
-vN3ZobW7s1fuzMvYsE8+bdP+b6Eb9oH0van4afWmomMhiB1Y7FZ0v9atCMQuaH9nVNBePzurM6F1T1dE
-/c7ukBq2/pCafxMjG75NyeyeM611PsMoGAUjFAAAQw1tDw;
-
-DEFINE LABEL 14
-eJzTY2Bg2Cjw3VJL+btljtY/u73azE6HNYV8g0Smrf5lMn0NUJrhonNkQ6x/ZMNGf+8yDn+HvJ0+tjnn
-Xexza52d8hucvEqbHGOarjvm9l10rph20q1p7kHPzkWpPp2L4v3aFoD0T4x2LpgYPWVVW3xMU11SSE1J
-WkjNgcyIepDc8yr34qmV7sXvy/0qPpXFNX8qK5zoVl4+9U1F3ayHNY1zbtY3ztFuLJl8sSm68WKTX4Vm
-k1epdqNXKcMoGAWjgCoAABe6Tio;
+f:
+    INBOX   
+    COPYTO   3
+    SUB      0
+    JUMPZ    d
+    COPYFROM 3
+    SUB      1
+    JUMPZ    e
+    COPYFROM 3
+    SUB      2
+    JUMPZ    f
+    COPYFROM 3
+    OUTBOX  
+g:
+h:
+i:
+j:
+    INBOX   
+    COPYTO   4
+    SUB      0
+    JUMPZ    g
+    COPYFROM 4
+    SUB      1
+    JUMPZ    h
+    COPYFROM 4
+    SUB      2
+    JUMPZ    i
+    COPYFROM 4
+    SUB      3
+    JUMPZ    j
+    COPYFROM 4
+    OUTBOX  
+k:
+    INBOX   
+    INBOX   
+    JUMP     k

--- a/38-Digit-Exploder.speed.asm
+++ b/38-Digit-Exploder.speed.asm
@@ -1,0 +1,149 @@
+-- HUMAN RESOURCE MACHINE PROGRAM --
+
+a:
+    COPYFROM 9
+    COPYTO   7
+    COPYTO   8
+    INBOX   
+    COPYTO   4
+    SUB      11
+    JUMPN    j
+    COPYTO   4
+    SUB      11
+    JUMPN    i
+    COPYTO   4
+    SUB      11
+    JUMPN    h
+    COPYTO   4
+    SUB      11
+    JUMPN    g
+    COPYTO   4
+    SUB      11
+    JUMPN    f
+    COPYTO   4
+    SUB      11
+    JUMPN    e
+    COPYTO   4
+    SUB      11
+    JUMPN    d
+    COPYTO   4
+    SUB      11
+    JUMPN    c
+    COPYTO   4
+    SUB      11
+    JUMPN    b
+    COPYTO   4
+    BUMPUP   8
+b:
+    BUMPUP   8
+c:
+    BUMPUP   8
+d:
+    BUMPUP   8
+e:
+    BUMPUP   8
+f:
+    BUMPUP   8
+g:
+    BUMPUP   8
+h:
+    BUMPUP   8
+i:
+    BUMPUP   8
+j:
+    COPYFROM 4
+    SUB      10
+    JUMPN    s
+    COPYTO   4
+    SUB      10
+    JUMPN    r
+    COPYTO   4
+    SUB      10
+    JUMPN    q
+    COPYTO   4
+    SUB      10
+    JUMPN    p
+    COPYTO   4
+    SUB      10
+    JUMPN    o
+    COPYTO   4
+    SUB      10
+    JUMPN    n
+    COPYTO   4
+    SUB      10
+    JUMPN    m
+    COPYTO   4
+    SUB      10
+    JUMPN    l
+    COPYTO   4
+    SUB      10
+    JUMPN    k
+    COPYTO   4
+    BUMPUP   7
+k:
+    BUMPUP   7
+l:
+    BUMPUP   7
+m:
+    BUMPUP   7
+n:
+    BUMPUP   7
+o:
+    BUMPUP   7
+p:
+    BUMPUP   7
+q:
+    BUMPUP   7
+r:
+    BUMPUP   7
+s:
+    COPYFROM 8
+    JUMPZ    v
+    OUTBOX  
+    COPYFROM 7
+t:
+    OUTBOX  
+u:
+    COPYFROM 4
+    OUTBOX  
+    JUMP     a
+v:
+    COPYFROM 7
+    JUMPZ    u
+    JUMP     t
+
+
+DEFINE LABEL 4
+eJzjZ2BgeNgyXyO1Wc+4oP6o84wCvf7VmbfW2STXnfCPEb0JlGY4Fr/FfEeKt4d44exGxsqj8zOaGE5d
+6VR7ykAAWPhKrivyD1n1OvDPjDWBhRM3+qt1WvvY5zp47cyQdNyZAVLDlLgltSRtwwStrLpZ8nnO8wKL
+WeZ3lNnPZqw0m1pdrdWztVa09kttUz5I7doGhrzlTbLNyi33Nj5skVyn0Nq1+HlT4US5Ntnmi123GjZO
+y+x+PWPLZNXZuXtA6o8um63KunyxNvuys57uy94nuiwPqKxbqdXza9WKHTtWbzn4aW3TaZC6xbOdC0QX
+Hi1kXe5cwLLfLJ3xgFGK3cHCZEL+GwWjYDgAANaHbE4;
+
+DEFINE LABEL 7
+eJwTZ2BguNiVohPUVWpRWmudtTpTduOOFPuTQGGGdRkMDgtypwfkNnAsutahtxcktmaG+WGhRXp7m5ev
+2X19+5rdHnuNDoDEoyKsj330tz42y8HowCZzowMuhhD12MBOn7YiD3f34uuOPOV37Nf0SjoWTgxw+THV
+2bNw4k6fzO7PfpINxv6Tq0v9WAq3+zLkaQdtmLAyqG3BmsBb69YEFu5fH8BwysI34vZx95h7aTb9V1ZY
+d198bt10GmT2gcT5LXVJdbMOJK7YAeJ7xQn67Ejh8QSxrau/W1bUmKXvquYp31prNMm4jnepYX3E2uSW
+kFW/J9nPBqnhLDuYx1JxMG9ps1FKT49Ryrrp39NB4ny7GfIitjPkvdpwssR8zcmS7iXXas8u1upxX/Z5
+0t+V1jMqVzfN3bHafeHuVf3LXJbPXn95Yeo2pTmZO3GFwSgYBYMFAAAprI4v;
+
+DEFINE LABEL 8
+eJwTY2BgMEpvc7kcdTDvn5fsRjGnkxeAQgzCzn1e/S59XrXea+L3Ja3ZrZPpfl4n0+cSSK63xP7k+3r7
+k169R89unHb0LEiMa6n9yaebnM8c2h9wVe94wFWGUTAKRsGQAADOsSVM;
+
+DEFINE LABEL 9
+eJyTZ2BgUGj9brmp7rPZ+eLPZo9y/tiUpHG4/U2aHtAZdzCvLyamSSCmbhZvbP+ylgSlLQxJK3ZkZu09
+fr3A+czRcuczS5u3HPw3kWNR+ZQ/Mz5Me96ZP/1oYdXkNfF8PYI+1tWvDfZXpugArWDQDsp8vjLo8aO/
+SZNXOlfszCiadlaaYRSMglEw4AAAyww8ZQ;
+
+DEFINE LABEL 10
+eJyTZ2BgyMlM0cnJFPT5lHattixVcl1Z6oZ9QGGGFzNLLdj6v1uKdba5yLVN9l3avCRSr+Fo4aa61I5N
+dW0L9Bpmr1/avOWgXJv9yekdR8+29x09WzX54Kn0WWrbry5oW+C59Hmny/KQGscV9rmOK3g8Tyz9bhm4
+KFP/7twYtZpJt1QYRsEoGAUDDgCmkTpv;
+
+DEFINE LABEL 11
+eJzTYWBg0A18baAdpJeoHdS/DMhlOFTx2uBsSa7R9YLPZplZXe6f0pZE/ko+WfIj5XVPXsafGdH5vEtP
+lfYv21vVtdi47sdUw/rXPWsbLlVpN66IAel3rniuu73mvfHW2s9maxtE/UFi9itfGziuyNQPWZipnzin
+1OLDtC73b1MUI35M9i77Mblq+rcpTXNzZnAsipnHsejCorYFjiuqpu9e9b5/89qI+s1rl0SarJ0eYL+S
+xZlhFIyCUUBVAABD5VLj;


### PR DESCRIPTION
Basic 9-cycle unrolled loop, code stays remarkably readable. Uses the existing 'size' solution digit-output code.

In theory can squeeze off 2 more cycles, but it would double the code-size by unrolling the 'output digit' code with decoders.